### PR TITLE
docs: add some signposting to blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Pact Cypress Adapter
-Generate pact contracts from cypress test.
-
 [![Build and test](https://github.com/pactflow/cypress-pact-adapter/actions/workflows/test-and-build.yaml/badge.svg)](https://github.com/pactflow/cypress-pact-adapter/actions/workflows/test-and-build.yaml) [![npm version](https://badge.fury.io/js/@pactflow%2Fpact-cypress-adapter.svg)](https://badge.fury.io/js/@pactflow%2Fpact-cypress-adapter)
+
+Generate Pact contracts from your existing Cypress tests. 
+
+> Accelerate your entry into contract testing with the Cypress development experience you know and love. — With Pact Cypress Adapter you can get the extra layer of testing safety, easily using existing mocks you’ve created with Cypress. 
+>
+> Read our [blog post](https://pactflow.io/blog/use-cypress-in-contract-testing/) to find out more, otherwise dive-right in.
 
 ## Installation
 **NPM**:


### PR DESCRIPTION
Hey @B3nnyL 

I would like to add some signposting on the repo to

- Blog post
- How to see it in action without implementing in your code base
  - Fork this [repo](https://github.com/pactflow/example-bi-directional-consumer-cypress) and run in Github action
  - Quick start guide and pick cypress as consumer https://docs.pactflow.io/docs/workshops/quick_starts/bdc/
  
  
 RE our cypress [PR](https://github.com/cypress-io/cypress-documentation/pull/4400/files#diff-9bd5d2c0f2d36aff04d0178b9d3a70711bb6da16d40f98adf512a4fba4459753R649)
 
 `Simple commands that generates pact from Cypress for pact test`

could we change the wording slightly

-  Simple commands to generate Pact contracts from your existing Cypress tests.
 
What do you think?
  