### PR TITLE
Added backwards compatabability by adding if() statement to currentTest usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,11 @@ const setupPactHeaderBlocklist = (headers: string[]) => {
 
 const usePactWait = (alias: AliasType) => {
   const formattedAlias = formatAlias(alias)
-  const testCaseTitle = Cypress.currentTest.title
+  // Cypress versions older than 8.2 do not have a currentTest objects
+  var testCaseTitle = ""
+  if (Cypress.hasOwnProperty("currentTest")){
+    testCaseTitle = Cypress.currentTest.title 
+  }
   //NOTE: spread only works for array containing more than one item
   if (formattedAlias.length > 1) {
     cy.wait([...formattedAlias]).spread((...intercepts) => {
@@ -68,7 +72,11 @@ const requestDataMap: AnyObject = {}
 
 const usePactGet = (alias: string) => {
   const formattedAlias = formatAlias(alias)
-  const testCaseTitle = Cypress.currentTest.title
+  // Cypress versions older than 8.2 do not have a currentTest objects
+  var testCaseTitle = ""
+  if (Cypress.hasOwnProperty("currentTest")){
+    testCaseTitle = Cypress.currentTest.title 
+  }
   formattedAlias.forEach((alias) => {
     cy.get(alias).then((response: any) => {
       const fullRequestAndResponse = {


### PR DESCRIPTION
This creates an if statement to check if Cypress is a version that support currentTest. If not then it leaves the value as an empty string. This has been tested locally with Cypress 7.6 and 9.5. Jest tests are all passing. 