### PR TITLE
Add ability to set provider state

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ before(() => {
     cy.setupPact('ui-consumer', 'api-provider')
 })
 ```
-### cy.usePactWait([alias] | alias)
+### cy.usePactWait([alias] | alias, providerState)
 Listen to aliased `cy.intercept` network call(s), record network request and response to a pact file.
 [Usage and example](https://docs.cypress.io/api/commands/intercept) about `cy.intercept`
 
@@ -86,7 +86,7 @@ before(() => {
 //... cypress test
 
 after(() => {
-    cy.usePactWait(['getAllUsers'])
+    cy.usePactWait(['getAllUsers'], 'providerState')
 })
 
 ```
@@ -105,11 +105,11 @@ before(() => {
 //... cypress test
 
 after(() => {
-    cy.usePactWait(['getAllUsers'])
+    cy.usePactWait(['getAllUsers'], 'providerState')
 })
 ```
 
-### cy.usePactRequest(option, alias) and cy.usePactGet([alias] | alias)
+### cy.usePactRequest(option, alias) and cy.usePactGet([alias] | alias, providerState)
 Use `cy.usePactRequest` to initiate network calls and use `cy.usePactGet` to record network request and response to a pact file.
 
 Convenience wrapper for `cy.request(options).as(alias)` 
@@ -133,7 +133,7 @@ before(() => {
 //... cypress test
 
 after(() => {
-    cy.usePactGet(['getAllUsers'])
+    cy.usePactGet(['getAllUsers'], 'providerState')
 })
 
 ```

--- a/example/todo-example/cypress/integration/todo.spec.js
+++ b/example/todo-example/cypress/integration/todo.spec.js
@@ -28,6 +28,8 @@ describe('example to-do app', () => {
   })
 
   after(() => {
-    cy.usePactWait('getTodos').its('response.statusCode').should('eq', 200)
+    cy.usePactWait('getTodos', 'Service ok')
+      .its('response.statusCode')
+      .should('eq', 200)
   })
 })

--- a/example/todo-example/cypress/integration/todoGet.spec.js
+++ b/example/todo-example/cypress/integration/todoGet.spec.js
@@ -22,7 +22,7 @@ describe('example to-do app', () => {
   })
 
   after(() => {
-    cy.usePactGet('getTodosGet')
+    cy.usePactGet('getTodosGet','Service ok')
       .its('response.statusCode')
       .should('eq', 200)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
-      usePactWait: (alias: AliasType) => Chainable
+      usePactWait: (alias: AliasType, providerState?: string) => Chainable
       usePactRequest: (option: AnyObject, alias: string) => Chainable
-      usePactGet: (alias: string, pactConfig: PactConfigType) => Chainable
+      usePactGet: (alias: string, pactConfig: PactConfigType, providerState?: string) => Chainable
       setupPact: (consumerName: string, providerName: string) => Chainable<null>
       setupPactHeaderBlocklist: (headers: string[]) => Chainable<null>
     }
@@ -36,7 +36,7 @@ const setupPactHeaderBlocklist = (headers: string[]) => {
   headersBlocklist = [...headers, ...headersBlocklist]
 }
 
-const usePactWait = (alias: AliasType) => {
+const usePactWait = (alias: AliasType, providerState: string = '') => {
   const formattedAlias = formatAlias(alias)
   // Cypress versions older than 8.2 do not have a currentTest objects
   const testCaseTitle = Cypress.currentTest ? Cypress.currentTest.title : ''
@@ -48,7 +48,8 @@ const usePactWait = (alias: AliasType) => {
           intercept,
           testCaseTitle: `${testCaseTitle}-${formattedAlias[index]}`,
           pactConfig,
-          blocklist: headersBlocklist
+          blocklist: headersBlocklist,
+          providerState: providerState,
         })
       })
     })
@@ -59,7 +60,8 @@ const usePactWait = (alias: AliasType) => {
         intercept: flattenIntercept,
         testCaseTitle: `${testCaseTitle}`,
         pactConfig,
-        blocklist: headersBlocklist
+        blocklist: headersBlocklist,
+        providerState: providerState
       })
     })
   }
@@ -67,7 +69,7 @@ const usePactWait = (alias: AliasType) => {
 
 const requestDataMap: AnyObject = {}
 
-const usePactGet = (alias: string) => {
+const usePactGet = (alias: string, pactConfig: PactConfigType, providerState: string = '') => {
   const formattedAlias = formatAlias(alias)
   // Cypress versions older than 8.2 do not have a currentTest objects
   const testCaseTitle = Cypress.currentTest ? Cypress.currentTest.title : ''
@@ -92,7 +94,8 @@ const usePactGet = (alias: string) => {
         intercept: fullRequestAndResponse,
         testCaseTitle: `${testCaseTitle}-${alias}`,
         pactConfig,
-        blocklist: headersBlocklist
+        blocklist: headersBlocklist,
+        providerState:providerState,
       })
     })
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,5 +74,6 @@ export type PactFileType = {
   testCaseTitle: string
   pactConfig: PactConfigType
   blocklist?: string[],
-  content?: any 
+  content?: any,
+  providerState: string,
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -82,7 +82,8 @@ describe('constructPactFile', () => {
         providerName: 'todo-api'
       },
       blocklist: [],
-      content: existingContent
+      content: existingContent,
+      providerState: 'State'
     })
     expect(result.interactions.length).toBe(2)
     expect(result.interactions[1].description).toBe('create todo')
@@ -106,7 +107,8 @@ describe('constructPactFile', () => {
       pactConfig: {
         consumerName: 'ui-consumer',
         providerName: 'todo-api'
-      }
+      },
+      providerState: 'State'
     })
     expect(result.consumer.name).toBe('ui-consumer')
     expect(result.provider.name).toBe('todo-api')


### PR DESCRIPTION
Similar to issue #16 we had the need to be able to set the provider state when using this plugin.

This pull request adds functionality to pass the state when calling **usePactGet** and **usePactWait**

The state is simply passed as a new parameter:

### New
```js
after(() => {
    cy.usePactWait(['getAllUsers'], 'providerState')
})
```
```js
after(() => {
    cy.usePactGet(['getAllUsers'], 'providerState')
})
```
### Old
```js
after(() => {
    cy.usePactWait(['getAllUsers'])
})
```
```js
after(() => {
    cy.usePactGet(['getAllUsers'])
})
```