### PR TITLE
chore(ci): run ci on PR updates

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -2,10 +2,11 @@ name: Build and test
 
 on:
   pull_request:
-    types: [opened]
+    branches:
+      - main
   push:
-      branches:
-        - '*'
+    branches:
+      - '*'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Instead of just when the PR is opened.