### PR TITLE
fix(types): preserve the `@`-prefix in formatAlias's return type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ import { Interception } from 'cypress/types/net-stubbing'
 
 export type AliasType = string | string[]
 
+export type PrefixedAliasType = `@${string}`
+
 export type AnyObject = {
   [K in string | number]: unknown
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,13 @@
 import { Interception } from 'cypress/types/net-stubbing'
-import { AliasType, Interaction, PactConfigType, XHRRequestAndResponse, PactFileType, HeaderType } from 'types'
+import {
+  AliasType,
+  Interaction,
+  PactConfigType,
+  PrefixedAliasType,
+  XHRRequestAndResponse,
+  PactFileType,
+  HeaderType
+} from 'types'
 import * as pjson from '../package.json'
 
 // Helper to keep only the latest item by property
@@ -35,9 +43,9 @@ const omit = <T extends Record<string, any>>(obj: T | undefined, keys: string[])
   }
   return result
 }
-export const formatAlias = (alias: AliasType) => {
+export const formatAlias = (alias: AliasType): PrefixedAliasType[] => {
   if (Array.isArray(alias)) {
-    return [...alias].map((a) => `@${a}`)
+    return [...alias].map((a): PrefixedAliasType => `@${a}`)
   }
   return [`@${alias}`]
 }


### PR DESCRIPTION
Cypress 15.18 narrowed `cy.wait`'s alias parameters from `string` to the template literal type `\`@\${string}\``. `formatAlias` already guarantees that prefix at runtime, but TypeScript widened its inferred return type to `string[]`, so passing the result to `cy.wait` no longer type checks — which is why #286 (cypress 15.18.1) fails its build.

This states the guarantee in the signature rather than relying on inference. No runtime change.

## Verification

Both run locally against the full build/test/lint:

| Cypress | `npm run build` | `npm test` | `npm run lint` |
|---|---|---|---|
| 15.13.1 (currently pinned) | pass | pass | pass |
| 15.18.1 (from #286) | pass | pass | pass |

Backward compatible, so it can land on `main` on its own and Renovate will rebase #286 onto it.